### PR TITLE
chore: added token to checkout repository

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -34,4 +34,5 @@ runs:
       uses: actions/checkout@v3
       with:
         path: ${{ env.CI_REPOSITORY_NAME }}
+        token: ${{ env.GH_TOKEN_SW_BOT }}
 


### PR DESCRIPTION
This fixes the issue with Frontend deployment.
Basically we were checking out the code without using the proper token with the permissions.
